### PR TITLE
Implement new Economy Interface of the DevLaunchersLibrary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>devlaunchers</groupId>
 	<artifactId>ByteEconomy</artifactId>
-	<version>0.0.3</version>
+	<version>0.0.4</version>
 	<packaging>jar</packaging>
 
 	<name>Currency</name>
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>com.github.dev-launchers</groupId>
 			<artifactId>minecraft__dev-launchers-library</artifactId>
-			<version>v0.0.3</version>
+			<version>v0.0.5</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/devlaunchers/byteeconomy/ByteEconomy.java
+++ b/src/main/java/devlaunchers/byteeconomy/ByteEconomy.java
@@ -41,6 +41,8 @@ public final class ByteEconomy extends DevLaunchersPlugin {
 		System.out.println("[ByteEconomy] [LOG] Plugin initializing..");
 		instance = this;
 		
+		ByteEconomyLibrary.getInstance();
+		
 		registerItem(DevLauncherItem.ECONOMY_BYTE_ITEM, getConfig().getItemStack("byte.item"));
 		
 		recipeManager = new RecipeManager();

--- a/src/main/java/devlaunchers/byteeconomy/ByteEconomyLibrary.java
+++ b/src/main/java/devlaunchers/byteeconomy/ByteEconomyLibrary.java
@@ -1,0 +1,112 @@
+package devlaunchers.byteeconomy;
+
+import java.util.HashMap;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.plugin.Plugin;
+
+import devlaunchers.economy.Economy;
+import devlaunchers.items.DevLauncherItem;
+import devlaunchers.items.ItemRepository;
+
+public class ByteEconomyLibrary extends Economy {
+
+  private ByteEconomyLibrary(Plugin economyPlugin) {
+    super(economyPlugin);
+  }
+
+  public static Economy getInstance() {
+    Economy economy = Economy.getInstance();
+    if (economy == null) {
+      return new ByteEconomyLibrary(ByteEconomy.getInstance());
+    }
+    return economy;
+  }
+
+  @Override
+  public int getBalance(Player player) {
+    ItemStack money = ItemRepository.getItem(DevLauncherItem.ECONOMY_BYTE_ITEM);
+
+    return player
+        .getInventory()
+        .all(money)
+        .values()
+        .stream()
+        .mapToInt((item) -> item.getAmount())
+        .sum();
+  }
+
+  @Override
+  public MoneyTransferResult giveMoney(Player player, int amount) {
+    PlayerInventory inventory = player.getInventory();
+
+    ItemStack money = ItemRepository.getItem(DevLauncherItem.ECONOMY_BYTE_ITEM).clone();
+
+    HashMap<Integer, ItemStack> toFill = new HashMap<Integer, ItemStack>();
+
+    for (int i = 0; i < inventory.getSize(); i++) {
+      if (inventory.getItem(i) == null) {
+        ItemStack clone = money.clone();
+        if (amount > money.getType().getMaxStackSize()) {
+          clone.setAmount(money.getType().getMaxStackSize());
+          amount -= money.getType().getMaxStackSize();
+        } else {
+          clone.setAmount(amount);
+          amount = 0;
+        }
+        toFill.put(i, clone);
+      } else if (money.isSimilar(inventory.getItem(i))) {
+        int iAmount = inventory.getItem(i).getAmount();
+        if (iAmount < money.getType().getMaxStackSize()) {
+          ItemStack clone = money.clone();
+          if (iAmount + amount > money.getType().getMaxStackSize()) {
+            clone.setAmount(money.getType().getMaxStackSize());
+            toFill.put(i, clone);
+            amount -= (money.getType().getMaxStackSize() - iAmount);
+          } else {
+            clone.setAmount(iAmount + amount);
+            toFill.put(i, clone);
+            amount = 0;
+          }
+        }
+      }
+    }
+    if (amount > 0) {
+      return MoneyTransferResult.INVENTORY_OVERFLOW;
+    }
+    toFill.forEach(
+        (i, item) -> {
+          inventory.setItem(i, item);
+        });
+    return MoneyTransferResult.SUCCESS;
+  }
+
+  @Override
+  public MoneyTransferResult takeMoney(Player player, int amount) {
+    if (getBalance(player) < amount) {
+      return MoneyTransferResult.INSUFFICIENT_BALANCE;
+    }
+    _takeMoney(player, amount);
+    return MoneyTransferResult.SUCCESS;
+  }
+
+  private void _takeMoney(Player player, int amount) {
+    ItemStack money = ItemRepository.getItem(DevLauncherItem.ECONOMY_BYTE_ITEM);
+    money.setAmount(amount);
+    player.getInventory().remove(money);
+  }
+
+  @Override
+  public MoneyTransferResult transferMoney(Player sender, Player receiver, int amount) {
+    if (getBalance(sender) < amount) {
+      return MoneyTransferResult.INSUFFICIENT_BALANCE;
+    }
+    if (giveMoney(receiver, amount) == MoneyTransferResult.INVENTORY_OVERFLOW) {
+      return MoneyTransferResult.INVENTORY_OVERFLOW;
+    }
+    _takeMoney(sender, amount);
+    return MoneyTransferResult.SUCCESS;
+  }
+}

--- a/src/main/java/devlaunchers/byteeconomy/commands/GiveByteCommand.java
+++ b/src/main/java/devlaunchers/byteeconomy/commands/GiveByteCommand.java
@@ -1,6 +1,7 @@
 package devlaunchers.byteeconomy.commands;
 
 import devlaunchers.byteeconomy.ByteEconomy;
+import devlaunchers.economy.Economy;
 import devlaunchers.items.DevLauncherItem;
 import devlaunchers.items.ItemRepository;
 
@@ -18,18 +19,11 @@ public class GiveByteCommand implements CommandExecutor {
         if (sender instanceof Player) {
             Player player = (Player) sender;
 
-            // Create a new ItemStack (type: diamond)
-            ItemStack byteItem = ItemRepository.getItem(DevLauncherItem.ECONOMY_BYTE_ITEM).clone();
-
             int numBytes = 1;
-            if (args[0] != null)
+            if (args.length > 0 && args[0] != null)
                 numBytes = Integer.parseInt(args[0]);
 
-            // Set the amount of the ItemStack
-            byteItem.setAmount(numBytes);
-
-            // Give the player our items (comma-seperated list of all ItemStack)
-            player.getInventory().addItem(byteItem);
+            Economy.getInstance().giveMoney(player, numBytes);
 
             System.out.println("[ByteEconomy] [LOG] Gave byte$! Amount: " + numBytes);
         }


### PR DESCRIPTION
The added Economy Interface allows any Plugin that will use the DevLaunchersLibrary to interact seamlessly with ByteEconomy (or something else if wanted).
It provides four Functions to get the Balance of a Player (counts Byte$ Items), give Money to a Player, take Money from a Player and to transfer Money from one Player to another. A Plugin that uses this does not need to know what Byte$ are.

Also Bumps Version to 0.0.4